### PR TITLE
fix compiler warnings

### DIFF
--- a/include/json-cpp/details/string_parser.hpp
+++ b/include/json-cpp/details/string_parser.hpp
@@ -25,37 +25,37 @@ namespace jsoncpp { namespace details
         else if (c < 0x800)
         {
             add(0xC0 | c >> 6);
-            add(0x80 | c & 0x3f);
+            add(0x80 | (c & 0x3f));
         }
         else if (c < 0x10000)
         {
             add(0xE0 | c >> 12);
-            add(0x80 | (c >> 6) & 0x3f);
-            add(0x80 | c & 0x3f);
+            add(0x80 | ((c >> 6) & 0x3f));
+            add(0x80 | (c & 0x3f));
         }
         else if (c < 0x200000)
         {
             add(0xF0 | c >> 18);
-            add(0x80 | (c >> 12) & 0x3f);
-            add(0x80 | (c >> 6) & 0x3f);
-            add(0x80 | c & 0x3f);
+            add(0x80 | ((c >> 12) & 0x3f));
+            add(0x80 | ((c >> 6) & 0x3f));
+            add(0x80 | (c & 0x3f));
         }
         else if (c < 0x4000000)
         {
             add(0xF8 | c >> 24);
-            add(0x80 | (c >> 18) & 0x3f);
-            add(0x80 | (c >> 12) & 0x3f);
-            add(0x80 | (c >> 6) & 0x3f);
-            add(0x80 | c & 0x3f);
+            add(0x80 | ((c >> 18) & 0x3f));
+            add(0x80 | ((c >> 12) & 0x3f));
+            add(0x80 | ((c >> 6) & 0x3f));
+            add(0x80 | (c & 0x3f));
         }
         else
         {
             add(0xFC | c >> 30);
-            add(0x80 | (c >> 24) & 0x3f);
-            add(0x80 | (c >> 18) & 0x3f);
-            add(0x80 | (c >> 12) & 0x3f);
-            add(0x80 | (c >> 6) & 0x3f);
-            add(0x80 | c & 0x3f);
+            add(0x80 | ((c >> 24) & 0x3f));
+            add(0x80 | ((c >> 18) & 0x3f));
+            add(0x80 | ((c >> 12) & 0x3f));
+            add(0x80 | ((c >> 6) & 0x3f));
+            add(0x80 | (c & 0x3f));
         }
     }
 


### PR DESCRIPTION
fix compiler warnings: "suggest parentheses around arithmetic in operand of '|' [-Wparentheses]"
